### PR TITLE
Add example contracts and tracing script

### DIFF
--- a/examples/contracts/MathLib.sol
+++ b/examples/contracts/MathLib.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.8.0;
+
+library MathLib {
+    function increment(uint self, uint amount) internal pure returns (uint) {
+        return self + amount;
+    }
+    function decrement(uint self, uint amount) internal pure returns (uint) {
+        return self - amount;
+    }
+}

--- a/examples/contracts/Token.sol
+++ b/examples/contracts/Token.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.0;
+
+import "./MathLib.sol";
+
+contract Token {
+    using MathLib for uint;
+
+    mapping(address => uint) public balances;
+
+    function deposit() external payable {
+        balances[msg.sender] = balances[msg.sender].increment(msg.value);
+    }
+
+    function withdraw(uint amount) external {
+        require(balances[msg.sender] >= amount, "insufficient");
+        balances[msg.sender] = balances[msg.sender].decrement(amount);
+        _transfer(msg.sender, amount);
+    }
+
+    function _transfer(address to, uint amount) internal {
+        payable(to).transfer(amount);
+    }
+}

--- a/examples/contracts/Wallet.sol
+++ b/examples/contracts/Wallet.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.0;
+
+import "./Token.sol";
+
+contract Wallet {
+    Token public token;
+
+    constructor(Token _token) {
+        token = _token;
+    }
+
+    function deposit() external payable {
+        token.deposit{value: msg.value}();
+    }
+
+    function withdraw(uint amount) external {
+        token.withdraw(amount);
+    }
+}

--- a/tracer.py
+++ b/tracer.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Trace Solidity call chains with source snippets.
+
+Usage:
+    python tracer.py <Contract::func> <files...>
+
+Requires `surya` to be installed and available in PATH.
+"""
+import argparse
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(cmd):
+    res = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    return res.stdout
+
+
+def parse_ftrace(text):
+    ansi = re.compile(r"\x1b\[[0-9;]*m")
+    functions = []
+    for line in text.splitlines():
+        line = ansi.sub('', line)
+        line = line.lstrip('│ ').lstrip('└─').strip()
+        if not line:
+            continue
+        if '::' not in line:
+            continue
+        func = line.split()[0]
+        functions.append(func)
+    return functions
+
+
+def extract_snippet(src: str, func: str) -> str | None:
+    """Return the Solidity code for `func` from `src`.
+
+    This performs a very small amount of parsing by locating the contract
+    definition first and then searching for the function inside that block.
+    """
+    contract, name = func.split("::", 1)
+
+    # Find contract or library body
+    c_pat = re.compile(r"(contract|library)\s+" + re.escape(contract) + r"\b[^\{]*\{",
+                       re.MULTILINE)
+    m_contract = c_pat.search(src)
+    if not m_contract:
+        return None
+    c_start = m_contract.end()
+    idx = c_start
+    depth = 1
+    while idx < len(src) and depth > 0:
+        if src[idx] == '{':
+            depth += 1
+        elif src[idx] == '}':
+            depth -= 1
+        idx += 1
+    contract_body = src[c_start:idx-1]
+
+    # Now search for the function within the contract body
+    f_pat = re.compile(r"function\s+" + re.escape(name) + r"\b[^\{]*\{",
+                       re.MULTILINE)
+    m_func = f_pat.search(contract_body)
+    if not m_func:
+        return None
+    f_start = m_func.start()
+    idx2 = m_func.end()
+    depth = 1
+    while idx2 < len(contract_body) and depth > 0:
+        if contract_body[idx2] == '{':
+            depth += 1
+        elif contract_body[idx2] == '}':
+            depth -= 1
+        idx2 += 1
+    return contract_body[f_start:idx2]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('entry', help='Entry point CONTRACT::FUNCTION')
+    ap.add_argument('files', nargs='+', help='Solidity sources')
+    args = ap.parse_args()
+
+    for bin_ in ('surya',):
+        if not shutil.which(bin_):
+            raise SystemExit(f'{bin_} not found in PATH')
+
+    with tempfile.TemporaryDirectory() as tmp:
+        flat = Path(tmp, 'flat.sol')
+        flat.write_text(run(['surya', 'flatten', *args.files]))
+        trace = run(['surya', 'ftrace', args.entry, 'all', *args.files])
+
+        src_text = flat.read_text()
+        funcs = parse_ftrace(trace)
+
+        print(f"\n== Call Trace for {args.entry} ==\n")
+        for f in funcs:
+            snippet = extract_snippet(src_text, f)
+            print(f'### {f}')
+            if snippet:
+                print(snippet)
+            else:
+                print('[source not found]')
+            print()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add tiny set of Solidity example contracts
- implement `tracer.py` for tracing Surya output and printing function snippets

## Testing
- `python3 tracer.py Wallet::withdraw examples/contracts/*.sol`

------
https://chatgpt.com/codex/tasks/task_e_6877911c6658832482969d3fe4a1ec8b