### PR TITLE
Fix tracer compatibility with Python 3.9

### DIFF
--- a/tracer.py
+++ b/tracer.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 
 def run(cmd):
@@ -34,7 +35,7 @@ def parse_ftrace(text):
     return functions
 
 
-def extract_snippet(src: str, func: str) -> str | None:
+def extract_snippet(src: str, func: str) -> Optional[str]:
     """Return the Solidity code for `func` from `src`.
 
     This performs a very small amount of parsing by locating the contract


### PR DESCRIPTION
## Summary
- add Optional from typing
- use Optional[str] return type for `extract_snippet`

## Testing
- `python -m py_compile tracer.py`
- `python tracer.py --help`


------
https://chatgpt.com/codex/tasks/task_e_687793cf36808324a329ff3e9f26c9bf