### PR TITLE
Add reverse tracing from sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ shows the source for each function that it encounters. Calls added through
 `using` library directives are also followed, so library functions invoked as
 extensions of built-in types will appear in the trace.
 
+To inspect the callers leading to a particular value transfer sink instead,
+use the `--from-sink` flag with the sink identifier printed by a regular run:
+
+```bash
+python tracer.py --from-sink Token::_transfer::SINK::transfer::0 examples/contracts/*.sol
+```
+
+Each reverse trace prints all possible entry points that can reach the sink.
+
 By default the trace also highlights low level calls and value transfer
 sinks (e.g. `transfer`, `selfdestruct`, `call{value: ...}`). Use the
 `--no-sinks` flag to suppress this extra information if a compact output

--- a/tests/test_revtrace.py
+++ b/tests/test_revtrace.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tracer import build_reverse, rev_paths
+
+
+def test_rev_paths_simple():
+    edges = [('A', 'B'), ('B', 'C'), ('D', 'C')]
+    rev = build_reverse(edges)
+    def is_entry(n):
+        return n in {'A', 'D'}
+    paths = list(rev_paths('C', rev, is_entry))
+    assert sorted(paths) == [['A', 'B', 'C'], ['D', 'C']]


### PR DESCRIPTION
## Summary
- support `--from-sink` flag for reverse call traces
- compute reverse call graph using Surya edges
- show all entry paths leading to the sink
- document new option
- add unit test for reverse path search

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879dcb0b7c4832488ca9dcc1afaae37